### PR TITLE
Possible Bug / Source Maps / Inline / Babel

### DIFF
--- a/backend-node/.babelrc
+++ b/backend-node/.babelrc
@@ -1,5 +1,6 @@
 {
   "presets": ["env"],
+  "sourceMaps": "inline",
   "plugins": [
     ["transform-runtime", {
       "polyfill": false,

--- a/backend-node/package.json
+++ b/backend-node/package.json
@@ -1,8 +1,8 @@
 {
     "scripts": {
-        "build": "babel src -d dist",
-        "build-tests": "babel src/messenger -d dist-tests/src/messenger && babel test -d dist-tests/test/",
-        "start": "rm -rf ./dist && npm run build && node ./dist/app.js",
+        "build": "babel src -d dist --source-maps inline",
+        "build-tests": "babel src/messenger -d dist-tests/src/messenger && babel test -d dist-tests/test/ --source-maps inline",
+        "start": "rm -rf ./dist && npm run build && node --inspect=0.0.0.0:9229  ./dist/app.js",
         "test": "rm -rf dist-tests && npm run build-tests && mocha dist-tests/test"
     },
     "dependencies": {

--- a/backend-node/src/messenger/message_routes.js
+++ b/backend-node/src/messenger/message_routes.js
@@ -1,7 +1,4 @@
 import * as MessageService from './message_service';
-import _ from 'lodash';
-
-
 export const BASE_MESSAGE_ROUTE = '/messages';
 
 export const SEND_TEXT_MESSAGE = async (request, response) => {
@@ -10,7 +7,7 @@ export const SEND_TEXT_MESSAGE = async (request, response) => {
     const message = request.body.message;
 
     await MessageService.addTextMessage(senderId, receiverId, message);
-    response.send(200);
+    response.sendStatus(200);
 };
 
 export const SEND_IMAGE_MESSAGE = async (request, response) => {
@@ -22,7 +19,7 @@ export const SEND_IMAGE_MESSAGE = async (request, response) => {
     const image_width = request.body.image_width;
 
     await MessageService.addImageMessage(senderId, receiverId, message, link, image_height, image_width);
-    response.send(200);
+    response.sendStatus(200);
 };
 
 export const SEND_VIDEO_MESSAGE = async (request, response) => {
@@ -33,7 +30,7 @@ export const SEND_VIDEO_MESSAGE = async (request, response) => {
     const video_source = request.body.video_source;
 
     await MessageService.addVideoMessage(senderId, receiverId, message, video_length, video_source);
-    response.send(200);
+    response.sendStatus(200);
 };
 
 export const FETCH_MESSAGES = async (request, response) => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
             - db
         ports:
             - "18000:8000"
+            - "9229:9229"
 
 volumes:  
     devmysqldb:

--- a/findings.md
+++ b/findings.md
@@ -6,6 +6,7 @@
 - Find Image ID: `docker images`
 - Build Image from current state `docker build ./`
 - Build Image from alternative Dockerfile `docker build -f Dockerfile.test ./`
+- Attach with a shell to running Container `docker exec -i -t <container_id> /bin/bash`
 
 #### NodeJS
 


### PR DESCRIPTION
### CHANGES

- Seems that sourceMaps inlined with babel don't load into a remote debugger configured as a Chromium remote debugger
- Using the Chromium Debugger with chrome://inspect connected to localhost:9229 works just fine and allows breakpoints in the source as well as navigating the full remote source tree with maps.
- To reproduce just run docker-compose up and try to connect to localhost:9229 with a Chromium remote config in Webstorm